### PR TITLE
Hardcoded Fall 2020 Fix

### DIFF
--- a/vu-registration.js
+++ b/vu-registration.js
@@ -120,12 +120,10 @@ async function saveCookie(username, password) {
         uri: `https://acad.app.vanderbilt.edu/more/SearchClasses!input.action?commodoreIdToLoad=${commodoreId}`,
         transform,
     });
-    const termCode = $('#selectedTerm')
-        .find('[selected="selected"]')
-        .attr('value');
+    const termCode = "0955";
 
     if (!termCode || !commodoreId) {
-        throw new Error(termCode + ' ' + commodoreId);
+        throw new Error("Update the term code (or commodoreId)!" + termCode + ' ' + commodoreId);
     }
 
     const result = { termCode, commodoreId };


### PR DESCRIPTION
The jQuery which selects the term code value doesn't seem to be working, and I wasn't able to figure it out so I decided to hardcode in the correct term code. For those looking at this in the future simply update the term code!